### PR TITLE
Sprawdzanie daty

### DIFF
--- a/PESEL.Tests/PeselValidatorTests.cs
+++ b/PESEL.Tests/PeselValidatorTests.cs
@@ -13,15 +13,17 @@
             ValidatePesel("02070803628");
             ValidatePesel("54071304899");
             ValidatePesel("48011809618");
+
+            ValidateInvalidPesel("86155009618");
         }
-        
+
         [TestMethod]
         public void ValidatePeselFromGeneratorTest()
         {
             var generator = new Generator();
 
             var peselList = generator.Generate(DateTime.Now.AddYears(-1));
-            
+
             var validator = new PeselValidator();
 
             foreach (var pesel in peselList)
@@ -43,6 +45,17 @@
             var validationResult = validator.Validate(entity);
 
             Assert.IsTrue(validationResult.IsValid);
-        } 
+        }
+
+        private static void ValidateInvalidPesel(string peselString)
+        {
+            var validator = new PeselValidator();
+
+            var entity = new PeselEntity(peselString);
+
+            var validationResult = validator.Validate(entity);
+
+            Assert.IsFalse(validationResult.IsValid);
+        }
     }
 }

--- a/PESEL/Validators/Impl/BirthDateValidator.cs
+++ b/PESEL/Validators/Impl/BirthDateValidator.cs
@@ -4,7 +4,7 @@
     using Models;
     using ValidationResults;
     using ValidationResults.Impl;
-    
+
     public class BirthDateValidator : IValidator
     {
         public IPeselValidationResult Validate(PeselEntity entity)
@@ -58,7 +58,13 @@
                 miesiac -= 80;
             }
 
-            return new DateTime(rok, miesiac, dzien);
+            bool isDateTime = DateTime.TryParse($"{rok:0000}-{miesiac:00}-{dzien:00}", out DateTime dateTime);
+            if (!isDateTime)
+            {
+                return null;
+            }
+
+            return dateTime;
         }
     }
 }


### PR DESCRIPTION
Witam,

sprawdzanie daty zgłasza wyjątek, jeśli data w PESEL ma miesiąc lub dzień poza zakresem. Przesyłam poprawkę.